### PR TITLE
feat: add explicit blocked state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Repository layout:
 - Olve.Diagrams.UI: Blazor WebAssembly UI using the library.
 - Olve.Diagrams.Tests: Unit tests for the library.
 - TaskDrawer.sln: solution including library, tests and UI.
+- Flowchart tasks can include '(done)' and '(blocked)' states.
 
 Coding guidelines:
 - Use conventional commits (feat:, fix:, chore: etc.).

--- a/Olve.Diagrams.Tests/AGENTS.md
+++ b/Olve.Diagrams.Tests/AGENTS.md
@@ -2,4 +2,5 @@ Tests project:
 - Uses TUnit for unit testing.
 - testdata/timelines contains sample timeline input files.
 - TimelineSerializationTests covers serialization logic.
+- Flowchart folder contains tests for task parsing including blocked state.
 

--- a/Olve.Diagrams.Tests/Flowchart/BlockedStateTests.cs
+++ b/Olve.Diagrams.Tests/Flowchart/BlockedStateTests.cs
@@ -1,0 +1,32 @@
+using Olve.Diagrams.Flowchart;
+using Olve.Results.TUnit;
+
+namespace Olve.Diagrams.Tests.Flowchart;
+
+public class BlockedStateTests
+{
+    [Test]
+    public async Task ExplicitBlocked_PropagatesToDependents()
+    {
+        string[] lines =
+        {
+            "1. initial",
+            "  a. (blocked) first step",
+            "  b. second step [1a]",
+            "2. final step [1]"
+        };
+
+        var result = TaskListParser.ParseTasks(lines);
+        await Assert.That(result).Succeeded();
+        var tasks = result.Value!;
+
+        var task1 = tasks[0];
+        var stepA = task1.SubTasks[0];
+        var stepB = task1.SubTasks[1];
+        var final = tasks[1];
+
+        await Assert.That(stepA.Blocked).IsTrue();
+        await Assert.That(stepB.Blocked).IsTrue();
+        await Assert.That(final.Blocked).IsTrue();
+    }
+}

--- a/Olve.Diagrams/Flowchart/AGENTS.md
+++ b/Olve.Diagrams/Flowchart/AGENTS.md
@@ -2,4 +2,5 @@ Flowchart module:
 - Converts task lists to Mermaid graphs using MermaidGenerator and Scriban template.
 - TaskListParser parses tasks; TaskListSorter orders them; TaskName provides typed names.
 - MermaidGenerator builds graph nodes and edges; colors indicate done/blocked status.
+- Tasks support '(done)' and '(blocked)' markers; blocked tasks propagate to dependents.
 

--- a/Olve.Diagrams/Flowchart/LineRegex.cs
+++ b/Olve.Diagrams/Flowchart/LineRegex.cs
@@ -20,10 +20,11 @@ public static partial class LineRegex
             match.Groups["indent"].Value,
             match.Groups["id"].Value[0..^1],
             match.Groups["done"].Success,
+            match.Groups["blocked"].Success,
             match.Groups["desc"].Value,
             match.Groups["blockers"].Value);
     }
     
-    [GeneratedRegex(@"(?<indent>\s*)(?<id>(?:\d+\.)|(?:[a-z]\.))\s*(?:(?<done>\(done\))\s*)?(?<desc>.*?)\s*(?=\s*\[|$)\s*(?<blockers>(?:\s*\[[^\]]+\])*)\s*", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
+    [GeneratedRegex(@"(?<indent>\s*)(?<id>(?:\d+\.)|(?:[a-z]\.))\s*(?:(?<done>\(done\))\s*)?(?:(?<blocked>\(blocked\))\s*)?(?<desc>.*?)\s*(?=\s*\[|$)\s*(?<blockers>(?:\s*\[[^\]]+\])*)\s*", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]
     public static partial Regex MyRegex();
 }

--- a/Olve.Diagrams/Flowchart/LineRegexMatch.cs
+++ b/Olve.Diagrams/Flowchart/LineRegexMatch.cs
@@ -1,3 +1,3 @@
 namespace Olve.Diagrams.Flowchart;
 
-public record LineRegexMatch(string Input, string Indentation, string Id, bool Done, string Description, string Blockers);
+public record LineRegexMatch(string Input, string Indentation, string Id, bool Done, bool Blocked, string Description, string Blockers);

--- a/Olve.Diagrams/Flowchart/Task.cs
+++ b/Olve.Diagrams/Flowchart/Task.cs
@@ -8,11 +8,14 @@ public class Task(TaskName name, string description)
     public string QualifiedName => string.Join("", Parents.Select(x => x.Name.Value));
     public string Description { get; } = description;
     public bool Done { get; set; }
+    public bool ExplicitBlocked { get; set; }
     public Task? Parent { get; set; }
     public List<Task> SubTasks { get; set; } = [];
     public Task[] Blockers { get; set; } = [];
-    
-    public bool Blocked => Blockers.Any(x => !x.Done) || SubTasks.Any(x => !x.Done);
+
+    public bool Blocked => ExplicitBlocked ||
+        Blockers.Any(x => x.Blocked || !x.Done) ||
+        SubTasks.Any(x => x.Blocked || !x.Done);
 
     public IEnumerable<Task> Parents => GetParents(this);
 
@@ -43,6 +46,11 @@ public class Task(TaskName name, string description)
         if (Done)
         {
             sb.Append("(done) ");
+        }
+
+        if (ExplicitBlocked)
+        {
+            sb.Append("(blocked) ");
         }
         
         sb.Append(Description);

--- a/Olve.Diagrams/Flowchart/TaskListParser.cs
+++ b/Olve.Diagrams/Flowchart/TaskListParser.cs
@@ -83,6 +83,7 @@ public static class TaskListParser
         var blockers = ParseBlockers(regexMatch.Blockers);
         var level = regexMatch.Indentation.Length / IndentationWidth;
         var done = regexMatch.Done;
+        var blockedExplicit = regexMatch.Blocked;
         
         while (parentStack.Count > level)
         {
@@ -97,6 +98,7 @@ public static class TaskListParser
         return new Task(new TaskName(id), description)
         {
             Done = done,
+            ExplicitBlocked = blockedExplicit,
             Parent = parent,
             Blockers = blockers
         };


### PR DESCRIPTION
## Summary
- support '(blocked)' state when parsing tasks
- propagate explicit blocked state to dependents
- show '(blocked)' in task ToString
- document new behaviour in AGENTS files
- add flowchart test for blocked state

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686dca8659ec832482011af7f6be7dab