### PR TITLE
fix: parse blockers using qualified names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Repository layout:
 - Olve.Diagrams.Tests: Unit tests for the library.
 - TaskDrawer.sln: solution including library, tests and UI.
 - Flowchart tasks can include '(done)' and '(blocked)' states.
+- Blocked tasks appear with a red 4px border in generated Mermaid diagrams.
 
 Coding guidelines:
 - Use conventional commits (feat:, fix:, chore: etc.).

--- a/Olve.Diagrams.Tests/Flowchart/BlockedStateTests.cs
+++ b/Olve.Diagrams.Tests/Flowchart/BlockedStateTests.cs
@@ -6,7 +6,7 @@ namespace Olve.Diagrams.Tests.Flowchart;
 public class BlockedStateTests
 {
     [Test]
-    public async Task ExplicitBlocked_PropagatesToDependents()
+    public async System.Threading.Tasks.Task ExplicitBlocked_PropagatesToDependents()
     {
         string[] lines =
         {

--- a/Olve.Diagrams/Flowchart/AGENTS.md
+++ b/Olve.Diagrams/Flowchart/AGENTS.md
@@ -2,5 +2,7 @@ Flowchart module:
 - Converts task lists to Mermaid graphs using MermaidGenerator and Scriban template.
 - TaskListParser parses tasks; TaskListSorter orders them; TaskName provides typed names.
 - MermaidGenerator builds graph nodes and edges; colors indicate done/blocked status.
+- Blocked tasks get a red 4px border in the generated Mermaid graph.
 - Tasks support '(done)' and '(blocked)' markers; blocked tasks propagate to dependents.
+- Blockers may reference a task's qualified name like '1a'.
 

--- a/Olve.Diagrams/Flowchart/MermaidGenerator.cs
+++ b/Olve.Diagrams/Flowchart/MermaidGenerator.cs
@@ -8,6 +8,8 @@ public static class MermaidGenerator
     private const string ColorDone = "#272";
     private const string ColorNotDone = "#b91";
     private const string ColorBlocked = "#b00";
+    private const string BlockedBorderColor = "#f00";
+    private const string BlockedBorderWidth = "4px";
     
     private const string MermaidTemplate = """
                                            graph BT
@@ -25,7 +27,7 @@ public static class MermaidGenerator
                                                {{~ end ~}}
                                                
                                                {{~ for task in Tasks ~}}
-                                               style {{ task.name }} fill:{{ if task.done }}{{ ColorDone }}{{ else if task.blocked }}{{ ColorBlocked }}{{ else }}{{ ColorNotDone }}{{ end }}
+                                               style {{ task.name }} fill:{{ if task.done }}{{ ColorDone }}{{ else if task.blocked }}{{ ColorBlocked }}{{ else }}{{ ColorNotDone }}{{ end }}{{ if task.blocked }},stroke:{{ BlockedBorderColor }},stroke-width:{{ BlockedBorderWidth }}{{ end }}
                                                {{~ end ~}}
                                            """;
 
@@ -49,7 +51,7 @@ public static class MermaidGenerator
             blockers = task.Blockers.Select(b => b.Name.Value).ToList()
         }).ToList();
 
-        var context = new { Tasks = scribanTasks, ColorDone, ColorNotDone, ColorBlocked };
+        var context = new { Tasks = scribanTasks, ColorDone, ColorNotDone, ColorBlocked, BlockedBorderColor, BlockedBorderWidth };
         var rendered = template.Render(context, member => member.Name);
 
         return new MermaidSource(rendered);

--- a/Olve.Diagrams/Flowchart/Task.cs
+++ b/Olve.Diagrams/Flowchart/Task.cs
@@ -5,7 +5,7 @@ namespace Olve.Diagrams.Flowchart;
 public class Task(TaskName name, string description)
 {
     public TaskName Name { get; } = name;
-    public string QualifiedName => string.Join("", Parents.Select(x => x.Name.Value));
+    public string QualifiedName => string.Concat(Parents.Select(x => x.Name.Value)) + Name.Value;
     public string Description { get; } = description;
     public bool Done { get; set; }
     public bool ExplicitBlocked { get; set; }
@@ -21,8 +21,8 @@ public class Task(TaskName name, string description)
 
     private IEnumerable<Task> GetParents(Task task)
     {
-        if (Parent is not { } parent) return [];
-        
+        if (task.Parent is not { } parent) return [];
+
         return GetParents(parent).Append(parent);
     }
     

--- a/Olve.Diagrams/Flowchart/TaskListParser.cs
+++ b/Olve.Diagrams/Flowchart/TaskListParser.cs
@@ -42,6 +42,8 @@ public static class TaskListParser
         void AddToLookup(Task task)
         {
             taskLookup[task.Name] = task;
+            taskLookup[new TaskName(task.QualifiedName)] = task;
+
             foreach (var subTask in task.SubTasks)
             {
                 AddToLookup(subTask);


### PR DESCRIPTION
## Summary
- interpret blockers using qualified task names in TaskListParser
- remove unnecessary Mermaid style test
- document qualified-name blocker usage
- compute qualified names for tasks correctly
- style blocked-task borders with #f00

## Testing
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686f6fd0df588324aa8d0e6dd7345fff