### PR TITLE
feat: show explicit blockers with bold outline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Repository layout:
 - Olve.Diagrams.Tests: Unit tests for the library.
 - TaskDrawer.sln: solution including library, tests and UI.
 - Flowchart tasks can include '(done)' and '(blocked)' states.
-- Blocked tasks appear with a red 4px border in generated Mermaid diagrams.
+- Explicitly blocked tasks have a red 4px border in generated Mermaid diagrams; other blocked tasks keep the default border.
 
 Coding guidelines:
 - Use conventional commits (feat:, fix:, chore: etc.).

--- a/Olve.Diagrams/Flowchart/AGENTS.md
+++ b/Olve.Diagrams/Flowchart/AGENTS.md
@@ -2,7 +2,7 @@ Flowchart module:
 - Converts task lists to Mermaid graphs using MermaidGenerator and Scriban template.
 - TaskListParser parses tasks; TaskListSorter orders them; TaskName provides typed names.
 - MermaidGenerator builds graph nodes and edges; colors indicate done/blocked status.
-- Blocked tasks get a red 4px border in the generated Mermaid graph.
+- Explicitly blocked tasks have a red 4px border in the generated Mermaid graph; tasks blocked indirectly keep the default border.
 - Tasks support '(done)' and '(blocked)' markers; blocked tasks propagate to dependents.
 - Blockers may reference a task's qualified name like '1a'.
 

--- a/Olve.Diagrams/Flowchart/MermaidGenerator.cs
+++ b/Olve.Diagrams/Flowchart/MermaidGenerator.cs
@@ -26,9 +26,9 @@ public static class MermaidGenerator
                                                {{~ end ~}}
                                                {{~ end ~}}
                                                
-                                               {{~ for task in Tasks ~}}
-                                               style {{ task.name }} fill:{{ if task.done }}{{ ColorDone }}{{ else if task.blocked }}{{ ColorBlocked }}{{ else }}{{ ColorNotDone }}{{ end }}{{ if task.blocked }},stroke:{{ BlockedBorderColor }},stroke-width:{{ BlockedBorderWidth }}{{ end }}
-                                               {{~ end ~}}
+                                                {{~ for task in Tasks ~}}
+                                                style {{ task.name }} fill:{{ if task.done }}{{ ColorDone }}{{ else if task.blocked }}{{ ColorBlocked }}{{ else }}{{ ColorNotDone }}{{ end }}{{ if task.explicitBlocked }},stroke:{{ BlockedBorderColor }},stroke-width:{{ BlockedBorderWidth }}{{ end }}
+                                                {{~ end ~}}
                                            """;
 
     public static Result<MermaidSource> GenerateMermaidSource(IReadOnlyList<Task> tasks)
@@ -46,6 +46,7 @@ public static class MermaidGenerator
             description = task.Description.Replace("\"", "\\\""),
             done = task.Done,
             blocked = task.Blocked,
+            explicitBlocked = task.ExplicitBlocked,
             parent = task.Parent?.Name.Value,
             subTasks = task.SubTasks.Select(s => s.Name.Value).ToList(),
             blockers = task.Blockers.Select(b => b.Name.Value).ToList()


### PR DESCRIPTION
## Summary
- make blocked-border style apply only to explicitly blocked tasks
- document new outline behaviour for blocked tasks

## Testing
- `dotnet build TaskDrawer.sln --no-restore --verbosity minimal`
- `dotnet test TaskDrawer.sln --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_686fa11ee0388324b1b9df7724a1cd9b